### PR TITLE
Correct order for Swift newtype printing

### DIFF
--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -55,9 +55,9 @@ prettySwiftDataWith indent = \case
     ++ prettyMoatType aliasTyp
 
   MoatNewtype{..} -> ""
-    ++ prettyProtocols newtypeProtocols
     ++ "enum "
     ++ prettyMoatTypeHeader newtypeName newtypeTyVars
+    ++ prettyProtocols newtypeProtocols
     ++ " {\n"
     ++ indents
     ++ "typealias "


### PR DESCRIPTION
Found a small bug where the `enum <ClassName>` was before the derivables 